### PR TITLE
(#33) Update launch script to add parameters on macOS

### DIFF
--- a/com.start-automating.scriptdeck.sdPlugin/StartPlugin.sh
+++ b/com.start-automating.scriptdeck.sdPlugin/StartPlugin.sh
@@ -1,11 +1,3 @@
 #!/bin/sh
 
-LOCAL_READLINK=readlink
-
-# https://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux
-unameOut="$(uname -s)"
-case "${unameOut}" in
-    Darwin*)    LOCAL_READLINK=greadlink;;
-esac
-
-pwsh -noprofile -nologo -file "$(dirname $(${LOCAL_READLINK} -f $0))/StartPlugin.ps1"
+pwsh -noprofile -nologo -file "./StartPlugin.ps1" $*


### PR DESCRIPTION
macOS parameters were missing being passed to the PowerShell script
As well, the readlink configuration did not seem to work.
